### PR TITLE
fix: Cannot assign bool to property Bluestone\Redmine\Entities\Version::$dueDate of type ?DateTime

### DIFF
--- a/src/Entities/Version.php
+++ b/src/Entities/Version.php
@@ -21,7 +21,7 @@ class Version extends DataTransferObject
     public ?string $status;
 
     #[Map('due_date')]
-    #[CastWith(DateTimeCaster::class)]
+    #[CastWith(DateTimeCaster::class, 'Y-m-d')]
     public ?DateTime $dueDate;
 
     public ?string $sharing;


### PR DESCRIPTION
As version `due_date` is in format `Y-m-d` the `DateTimeCaster` returns `false` thus giving an 500 error